### PR TITLE
Implementar clase Prestamo

### DIFF
--- a/biblioteca-testing/src/main/java/com/biblioteca/modelo/Prestamo.java
+++ b/biblioteca-testing/src/main/java/com/biblioteca/modelo/Prestamo.java
@@ -1,0 +1,44 @@
+package com.biblioteca.modelo;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+public class Prestamo {
+
+    private final Libro libro;
+    private final LocalDate fechaPrestamo;
+
+    public Prestamo(Libro libro) {
+        this.libro = Objects.requireNonNull(libro, "El libro no puede ser nulo para crear un préstamo.");
+        this.fechaPrestamo = LocalDate.now();
+    }
+
+    public Libro getLibro() {
+        return libro;
+    }
+
+    public LocalDate getFechaPrestamo() {
+        return fechaPrestamo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Prestamo prestamo = (Prestamo) o;
+        return Objects.equals(libro, prestamo.libro) && Objects.equals(fechaPrestamo, prestamo.fechaPrestamo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(libro, fechaPrestamo);
+    }
+
+    @Override
+    public String toString() {
+        return "Prestamo{" +
+                "libro=" + (libro != null ? "'" + libro.getTitulo() + "'" : "null") +
+                ", fechaPrestamo=" + fechaPrestamo +
+                '}';
+    }
+}


### PR DESCRIPTION
Closes #12 .

Implementa la clase `Prestamo` para representar un préstamo.

**Cambios:**
- Creada clase `Prestamo` en `com.biblioteca.modelo` con atributos `libro` (Libro) y `fechaPrestamo` (LocalDate).
- Constructor inicializa la fecha automáticamente (`LocalDate.now()`).
- Implementados getters y métodos `equals`/`hashCode`/`toString`.